### PR TITLE
goupnp: clean up oddities

### DIFF
--- a/httpu/httpu.go
+++ b/httpu/httpu.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 // ClientInterface is the general interface provided to perform HTTP-over-UDP
 // requests.
 type ClientInterface interface {
+	io.Closer
 	// Do performs a request. The timeout is how long to wait for before returning
 	// the responses that were received. An error is only returned for failing to
 	// send the request. Failures in receipt simply do not add to the resulting

--- a/httpu/multiclient.go
+++ b/httpu/multiclient.go
@@ -17,9 +17,14 @@ var _ ClientInterface = &MultiClient{}
 // NewMultiClient creates a new MultiClient that delegates to all the given
 // clients.
 func NewMultiClient(delegates []ClientInterface) *MultiClient {
-	return &MultiClient{
-		delegates: delegates,
+	return &MultiClient{delegates: delegates}
+}
+
+func (mc *MultiClient) Close() error {
+	for _, d := range mc.delegates {
+		d.Close()
 	}
+	return nil
 }
 
 // Do implements ClientInterface.Do.

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -34,7 +34,10 @@ func NewSOAPClient(endpointURL url.URL) *SOAPClient {
 // PerformSOAPAction makes a SOAP request, with the given action.
 // inAction and outAction must both be pointers to structs with string fields
 // only.
-func (client *SOAPClient) PerformAction(ctx context.Context, actionNamespace, actionName string, inAction interface{}, outAction interface{}) error {
+func (client *SOAPClient) PerformAction(
+	ctx context.Context, actionNamespace, actionName string,
+	inAction interface{}, outAction interface{},
+) error {
 	requestBytes, err := encodeRequestAction(actionNamespace, actionName, inAction)
 	if err != nil {
 		return err
@@ -73,20 +76,18 @@ func (client *SOAPClient) PerformAction(ctx context.Context, actionNamespace, ac
 		return fmt.Errorf("goupnp: SOAP request got HTTP %s", response.Status)
 	}
 
-	if outAction != nil {
-		if err := xml.Unmarshal(responseEnv.Body.RawAction, outAction); err != nil {
-			return fmt.Errorf("goupnp: error unmarshalling out action: %v, %v", err, responseEnv.Body.RawAction)
-		}
+	if outAction == nil {
+		return nil
 	}
-
+	if err := xml.Unmarshal(responseEnv.Body.RawAction, outAction); err != nil {
+		return fmt.Errorf("goupnp: error unmarshalling out action: %v, %v", err, responseEnv.Body.RawAction)
+	}
 	return nil
 }
 
 // newSOAPAction creates a soapEnvelope with the given action and arguments.
 func newSOAPEnvelope() *soapEnvelope {
-	return &soapEnvelope{
-		EncodingStyle: soapEncodingStyle,
-	}
+	return &soapEnvelope{EncodingStyle: soapEncodingStyle}
 }
 
 // encodeRequestAction is a hacky way to create an encoded SOAP envelope


### PR DESCRIPTION
Previously, there was some timing code in the goupnp client which relied on hard-coded seconds
which may have conflicted with the context timing. Since it requires 1 seconds according to the
spec, take the max of that and the context time.