### PR TITLE
goupnp: add context key for httpClient

### DIFF
--- a/device.go
+++ b/device.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/tailscale/goupnp/scpd"
@@ -161,8 +162,14 @@ func (srv *Service) RequestSCPD(ctx context.Context) (*scpd.SCPD, error) {
 	return s, nil
 }
 
-func (srv *Service) NewSOAPClient() *soap.SOAPClient {
-	return soap.NewSOAPClient(srv.ControlURL.URL)
+// NewSOAPClient returns a new SOAP client to the service's control
+// URL, using the provided http.Client.
+// If httpc is nil, http.DefaultClient is used.
+func (srv *Service) NewSOAPClient(httpc *http.Client) *soap.SOAPClient {
+	if httpc == nil {
+		httpc = http.DefaultClient
+	}
+	return soap.NewSOAPClient(srv.ControlURL.URL, httpc)
 }
 
 // URLField is a URL that is part of a device description.

--- a/service_client.go
+++ b/service_client.go
@@ -68,11 +68,10 @@ func NewServiceClientsFromRootDevice(ctx context.Context, rootDevice *RootDevice
 		return nil, fmt.Errorf("goupnp: service %q not found within device %q (UDN=%q)",
 			searchTarget, device.FriendlyName, device.UDN)
 	}
-
 	clients := make([]ServiceClient, 0, len(srvs))
 	for _, srv := range srvs {
 		clients = append(clients, ServiceClient{
-			SOAPClient: srv.NewSOAPClient(),
+			SOAPClient: srv.NewSOAPClient(httpClient(ctx)),
 			RootDevice: rootDevice,
 			Location:   loc,
 			Service:    srv,

--- a/soap/soap.go
+++ b/soap/soap.go
@@ -22,12 +22,15 @@ const (
 
 type SOAPClient struct {
 	EndpointURL url.URL
-	HTTPClient  http.Client
+	HTTPClient  *http.Client
 }
 
-func NewSOAPClient(endpointURL url.URL) *SOAPClient {
+// NewSoapClient creates a new soap client to a specific URL using a given http.Client.
+// The http.Client must not be nil.
+func NewSOAPClient(endpointURL url.URL, httpClient *http.Client) *SOAPClient {
 	return &SOAPClient{
 		EndpointURL: endpointURL,
+		HTTPClient:  httpClient,
 	}
 }
 

--- a/soap/soap_test.go
+++ b/soap/soap_test.go
@@ -45,7 +45,7 @@ func TestActionInputs(t *testing.T) {
 	}
 	client := SOAPClient{
 		EndpointURL: *url,
-		HTTPClient: http.Client{
+		HTTPClient: &http.Client{
 			Transport: rt,
 		},
 	}


### PR DESCRIPTION
This allows for users of the library to pass their own http client per call on the context.